### PR TITLE
Fix docker build due to missing rust compiler, and compile for both platforms

### DIFF
--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -55,6 +55,7 @@ jobs:
           push: true
           tags: ${{ env.DOCKER_REGISTRY }}/${{ env.IMAGE_NAME }}:latest
           labels: version=${{ github.run_id }}
+          platforms: linux/amd64,linux/arm64
 
       # For tagged releases, build and push the Docker image with the corresponding tag
       - name: Build and Push Docker Image (Tagged)
@@ -66,6 +67,7 @@ jobs:
           push: true
           tags: ${{ env.DOCKER_REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.ref_name }}
           labels: version=${{ github.run_id }}
+          platforms: linux/amd64,linux/arm64
 
   build-and-push-alt-image:
     runs-on: ubuntu-latest
@@ -113,6 +115,7 @@ jobs:
           push: true
           tags: ${{ env.DOCKER_REGISTRY }}/${{ env.IMAGE_NAME }}:latest
           labels: version=${{ github.run_id }}
+          platforms: linux/amd64,linux/arm64
 
       # For tagged releases, build and push the Docker image with the corresponding tag
       - name: Build and Push Docker Image (Tagged)
@@ -124,4 +127,5 @@ jobs:
           push: true
           tags: ${{ env.DOCKER_REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.ref_name }}
           labels: version=${{ github.run_id }}
+          platforms: linux/amd64,linux/arm64
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,13 @@
-FROM python:3.11-slim
+FROM python:3.11
 
 RUN apt-get update && \
     apt-get install --no-install-recommends -y curl ffmpeg git && \
     apt-get clean && rm -rf /var/lib/apt/lists/*
+
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+
+ENV PATH="/root/.cargo/bin:${PATH}"
+
 
 WORKDIR /app
 RUN mkdir -p voices config

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11
+FROM python:3.11-slim
 
 RUN apt-get update && \
     apt-get install --no-install-recommends -y curl ffmpeg git && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,6 @@ RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
 
 ENV PATH="/root/.cargo/bin:${PATH}"
 
-
 WORKDIR /app
 RUN mkdir -p voices config
 

--- a/Dockerfile.min
+++ b/Dockerfile.min
@@ -4,6 +4,10 @@ RUN apt-get update && \
     apt-get install --no-install-recommends -y curl ffmpeg && \
     apt-get clean && rm -rf /var/lib/apt/lists/*
 
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+
+ENV PATH="/root/.cargo/bin:${PATH}"
+
 WORKDIR /app
 RUN mkdir -p voices config
 


### PR DESCRIPTION
The build image did not have a rust compiler, and some of the pip packages now require it.