### PR TITLE
detecting and using multiple languages automatically (xtts)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@ uvicorn
 loguru
 piper-tts
 coqui-tts[languages]
+langdetect
 # Creating an environment where deepspeed works is complex, for now it will be disabled by default.
 #deepspeed
 


### PR DESCRIPTION
This code detect the language of the request and set it automatically, enabling seamless support for non-English languages, as in the openai api. Enabled by default.

- Only for xtts, but could be done with piper too, with some thinkering
- Uses the module landetect to infer the language of each request
- Only does that if the language field of the voice is not defined or is "auto"
- Could be modified to do it by sentence or paragraph 
- Can be disabled by setting a fixed language in the voice settings