### PR TITLE
ROCM/AMD requirements file

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -14,4 +14,4 @@ torchaudio; sys_platform != "darwin"
 torch; --index-url https://download.pytorch.org/whl/cpu; sys_platform == "darwin"
 torchaudio; --index-url https://download.pytorch.org/whl/cpu; sys_platform == "darwin"
 
-# ROCM (Linux only) - use requirements.amd.txt
+# ROCM (Linux only) - use requirements-rocm.txt


### PR DESCRIPTION
`requirements.amd.txt` doesn't exist, but it's likely just renamed to `requirements-rocm.txt`