### PR TITLE
use better portable shebang in scripts

### DIFF
--- a/download_samples.sh
+++ b/download_samples.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 for i in alloy echo fable onyx nova shimmer; do
 	[ ! -e "voices/$i.wav" ] && curl -s https://cdn.openai.com/API/docs/audio/$i.wav | ffmpeg -loglevel error -i - -ar 22050 -ac 1 voices/$i.wav
 done

--- a/download_voices_tts-1-hd.sh
+++ b/download_voices_tts-1-hd.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 export COQUI_TOS_AGREED=1
 export TTS_HOME=voices
 

--- a/download_voices_tts-1.sh
+++ b/download_voices_tts-1.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 models=${*:-"en_GB-northern_english_male-medium en_US-libritts_r-medium"} # en_US-ryan-high
 piper --update-voices --data-dir voices --download-dir voices --model x 2> /dev/null
 for i in $models ; do

--- a/startup.min.sh
+++ b/startup.min.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 [ -f speech.env ] && . speech.env
 

--- a/startup.sh
+++ b/startup.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 [ -f speech.env ] && . speech.env
 

--- a/test_voices.sh
+++ b/test_voices.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 URL=${1:-http://localhost:8000/v1/audio/speech}
 


### PR DESCRIPTION
Thanks for the work on this server.

I was running into a small issue of not being able to directly run the script due to bash not being in the path specified by the shebang.

The PR updates the shebang to make it more portable across systems.