### PR TITLE
 Fix Device Permission Issue with /dev/kfd in Docker Compose Setup & piper-tts Conflict

### DIFF
--- a/docker-compose.rocm.yml
+++ b/docker-compose.rocm.yml
@@ -25,3 +25,4 @@ services:
       - video
       - audio
     ipc: host
+    privileged: true

--- a/requirements-rocm.txt
+++ b/requirements-rocm.txt
@@ -1,7 +1,7 @@
 fastapi
 uvicorn
 loguru
-piper-tts
+piper-tts==1.2.0
 coqui-tts[languages]
 langdetect
 pyyaml


### PR DESCRIPTION
This pull request addresses 2 issues:

1. Encountered when using docker-compose -f docker-compose.rocm.yml up. The error message "no such file or directory" was triggered while attempting to attach /dev/kfd as a custom device. This problem arises due to insufficient permissions for accessing the device.

Error:

Attaching to openedai-speech-server-1
Error response from daemon: error gathering device information while adding custom device "/dev/kfd": no such file or directory

Solution: [docker-compose.rocm.yml](https://github.com/matatonic/openedai-speech/pull/83/commits/8a83eccefbf36f505b9e0f8da69a3db1ba378393)

2. When piper-tts version is not specified in requirements-rocm.txt, conflicts arise due to differing dependencies: 

        piper-tts 1.2.0 requires piper-phonemize~=1.1.0.
        piper-tts 1.1.0 requires piper-phonemize~=1.0.0.
        
 Thus it throws:
 
  ERROR: Cannot install -r requirements-rocm.txt (line 4) because these package versions have conflicting dependencies.
  
  Solution: [requirements-rocm.txt](https://github.com/matatonic/openedai-speech/pull/83/commits/8c47a976e2e1ba5e805443ee81180b508b52d1ca)