### PR TITLE
Fix speech.py issue - spamming UnboundLocalError

### DIFF
--- a/speech.py
+++ b/speech.py
@@ -389,8 +389,11 @@ async def generate_speech(request: GenerateSpeechRequest):
 
         def cleanup():
             ffmpeg_proc.kill()
-            del generator_worker
-            del out_writer_worker
+            # Check if variables exist in local scope before deleting them
+            if 'generator_worker' in locals():
+                del generator_worker
+            if 'out_writer_worker' in locals():
+                del out_writer_worker
 
         return StreamingResponse(content=ffmpeg_proc.stdout, media_type=media_type, background=cleanup)
     else:


### PR DESCRIPTION
Fixed the error in speech.py that was causing the UnboundLocalError: cannot access local variable 'generator_worker' where it is not associated with a value exception.

The issue was in the cleanup function that runs as a background task after a request finishes. The function was trying to delete the variables generator_worker and out_writer_worker without checking if they exist first. This caused the error when the cleanup function executed in a scenario where these variables weren't properly initialized.

The fix adds checks to ensure these variables exist in the local scope before attempting to delete them.