### PR TITLE
Fix Piper-related issues caused by CLI interface changes in v1.3.0

### DIFF
--- a/download_voices_tts-1.bat
+++ b/download_voices_tts-1.bat
@@ -2,7 +2,6 @@
 set models=%* 
 if "%models%" == "" set models=en_GB-northern_english_male-medium en_US-libritts_r-medium
 
-piper --update-voices --data-dir voices --download-dir voices --model x 2> nul
 for %%i in (%models%) do (
-    if not exist "voices\%%i.onnx" piper --data-dir voices --download-dir voices --model %%i > nul
+    if not exist "voices\%%i.onnx" python -m piper.download_voices --data-dir voices %%i > nul
 )

--- a/download_voices_tts-1.sh
+++ b/download_voices_tts-1.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 models=${*:-"en_GB-northern_english_male-medium en_US-libritts_r-medium"} # en_US-ryan-high
-piper --update-voices --data-dir voices --download-dir voices --model x 2> /dev/null
+
 for i in $models ; do
-    [ ! -e "voices/$i.onnx" ] && piper --data-dir voices --download-dir voices --model $i < /dev/null > /dev/null
+    [ ! -e "voices/$i.onnx" ] && python -m piper.download_voices --data-dir voices $i < /dev/null > /dev/null
 done

--- a/speech.py
+++ b/speech.py
@@ -223,7 +223,7 @@ async def generate_speech(request: GenerateSpeechRequest):
 
         speaker = voice_map.get('speaker', None)
 
-        tts_args = ["piper", "--model", str(piper_model), "--data-dir", "voices", "--download-dir", "voices", "--output-raw"]
+        tts_args = ["piper", "--model", str(piper_model), "--data-dir", "voices", "--output-raw"]
         if speaker:
             tts_args.extend(["--speaker", str(speaker)])
         if speed != 1.0:


### PR DESCRIPTION
First of all, thank you for this fantastic project!

I recently discovered this project and tried to get it running, but encountered a few issues preventing it from working correctly. Specifically, when attempting to use TTS with openwebui, all audio output said "Download DIR voices." Additionally, voice downloading was broken, requiring me to manually download the voices and place them in the `voices` folder.

After investigating, I found that piper has been updated to version 1.3.0, and some of the CLI arguments used in this project are now invalid. The changes in this pull request seem to resolve these issues, and the project is now working as expected.

Here's the reference I used to update the CLI arguments:
https://github.com/OHF-Voice/piper1-gpl/blob/main/docs/CLI.md

I understand this project is no longer actively maintained, but I'm submitting this information in hopes it will be helpful to others who encounter the same problems.

For those running into these issues, you can alternatively clone my fork and build the Docker image:
https://github.com/myeungdev/openedai-speech/tree/piper-v1.3.0